### PR TITLE
fix: 結果表示画面の得点数表示に関する修正とコメント追加.

### DIFF
--- a/src/utils/QuizBtn.tsx
+++ b/src/utils/QuizBtn.tsx
@@ -8,7 +8,7 @@ import { useInputAct } from "../hooks/btns/useInputAct";
 
 type quizBtnType = {
     getData: quizType[];
-    scorePointRef: React.RefObject<number>;
+    scorePointRef: React.RefObject<number>; // このコンポーネントで得点数を取得している
     withTransition_fetchAnswersDataAction: () => void;
 };
 

--- a/src/utils/QuizBtnViewAnswerWrapper.tsx
+++ b/src/utils/QuizBtnViewAnswerWrapper.tsx
@@ -52,6 +52,7 @@ export const QuizBtnViewAnswerWrapper = memo(({ fetchdataPromise }: { fetchdataP
                 ((questionCounter + 1) * 10) / (questionCounter + 1) :
                 (questionCounter + 1) * 10;
 
+            /* urlPathPart： フェッチする回答結果JSONファイルのパス名 */
             let urlPathPart: string = 'answer-low.json';
             if (scorePointRef.current >= highScorePoint) {
                 urlPathPart = 'answer-high.json';
@@ -92,7 +93,9 @@ export const QuizBtnViewAnswerWrapper = memo(({ fetchdataPromise }: { fetchdataP
                     {isPending ? <p>結果読み込み中</p> : <p>ゲームクリア！</p>}
                     <ViewAnswers props={{
                         getData: getData,
-                        scorePointRef: scorePointRef,
+                        scorePointRef: hasAdjustProp_absolute_100_flag ?
+                            Math.floor(scorePointRef.current / questionCounter) :
+                            scorePointRef,
                         fetchAnswersData: fetchAnswersData
                     }} />
                 </>

--- a/src/utils/ViewAnswers.tsx
+++ b/src/utils/ViewAnswers.tsx
@@ -6,7 +6,7 @@ import { useViewQuizAndAnswers } from "../hooks/answers/useViewQuizAndAnswers";
 type viewAnswersType = {
     getData: quizType[];
     fetchAnswersData: answerResultType[];
-    scorePointRef: React.RefObject<number>;
+    scorePointRef: React.RefObject<number> | number;
 };
 
 const TheCommonContent = ({ answer, isSingleComments }: {
@@ -52,7 +52,10 @@ export const ViewAnswers = memo(({ props }: { props: viewAnswersType }) => {
         <ViewAnswersElm>
             {fetchAnswersData.length > 0 ?
                 <div className="resultViewTxt">
-                    <h2>得点：{scorePointRef.current}</h2>
+                    <h2>得点：{
+                        typeof scorePointRef === 'number' ?
+                            scorePointRef : scorePointRef.current
+                    }</h2>
                     {/* コメント（所感）が一つだけの場合 */}
                     {isSingleComments &&
                         <div className="resultViewSentence">


### PR DESCRIPTION
- 結果表示画面の得点数表示に関する修正とコメント追加
  - `src/utils/QuizBtn.tsx`<br>コメント追加
  - `src/utils/QuizBtnViewAnswerWrapper.tsx`<br>`hasAdjustProp_absolute_100_flag`真偽値の状態次第で得点数の計算処理（必ず100にする）をするか否かの判定分岐処理とコメント追加
  - `src/utils/ViewAnswers.tsx`<br>得点数の`props`の型注釈を修正及び型の違いによる表示内容の分岐処理