### PR TITLE
fix: 結果表示ページの回答状況を示すテキスト（isPending）のスタイル調整.

### DIFF
--- a/src/FetchDataAndLoading.tsx
+++ b/src/FetchDataAndLoading.tsx
@@ -40,4 +40,9 @@ const QuizComponent = styled.section`
     font-size: 16px;
     line-height: 2;
 }
+
+& .isPending{
+    text-align: center;
+    margin-bottom: .5em;
+}
 `;

--- a/src/utils/QuizBtnViewAnswerWrapper.tsx
+++ b/src/utils/QuizBtnViewAnswerWrapper.tsx
@@ -90,7 +90,7 @@ export const QuizBtnViewAnswerWrapper = memo(({ fetchdataPromise }: { fetchdataP
                     withTransition_fetchAnswersDataAction: withTransition_fetchAnswersDataAction
                 }} /> :
                 <>
-                    {isPending ? <p>結果読み込み中</p> : <p>ゲームクリア！</p>}
+                    {isPending ? <p className="isPending">結果読み込み中</p> : <p className="isPending">ゲームクリア！</p>}
                     <ViewAnswers props={{
                         getData: getData,
                         scorePointRef: hasAdjustProp_absolute_100_flag ?


### PR DESCRIPTION
- 結果表示ページの回答状況を示すテキスト（isPending）のスタイル調整
  - `src/FetchDataAndLoading.tsx`<br>class（`.isPending`）のスタイル指定
  - `src/utils/QuizBtnViewAnswerWrapper.tsx`<br>結果表示ページの回答状況を示すテキストに class（`.isPending`）指定